### PR TITLE
Fix #66: prevent scroll on drill training view

### DIFF
--- a/app/controllers/drills_controller.rb
+++ b/app/controllers/drills_controller.rb
@@ -110,8 +110,7 @@ class DrillsController < ApplicationController
     end
 
     def validate_numeric_id
-      unless params[:id].to_s.match?(/\A\d+\z/)
-        redirect_to drills_path, alert: "Invalid drill ID."
-      end
+      return if params[:id].to_s.match?(/\A\d+\z/)
+      redirect_to drills_path, alert: "Invalid drill ID."
     end
 end

--- a/app/views/drills/_clue.html.erb
+++ b/app/views/drills/_clue.html.erb
@@ -1,6 +1,6 @@
-<div class="bg-blue-900 rounded-lg shadow-lg p-8 max-w-3xl min-h-min mx-auto">
+<div class="bg-blue-900 rounded-lg shadow-lg p-4 md:p-6 max-w-3xl min-h-min mx-auto">
   <!-- Clue Display -->
-  <div class="mb-8 text-center">
+  <div class="mb-4 text-center">
     <div class="mb-4">
       <span class="inline-block px-4 py-1 bg-blue-100
                    text-blue-800 rounded-full text-sm font-semibold">
@@ -14,11 +14,11 @@
     <h2 class="text-2xl font-bold text-yellow-500 mb-2">
       <%= clue.category %>
     </h2>
-    <div class="text-4xl font-bold text-yellow-500 mb-6">
+    <div class="text-2xl font-bold text-yellow-500 mb-3">
       <%= format_currency(clue.normalized_clue_value) %>
     </div>
     <!-- Clue Text -->
-    <div class="bg-blue-900 text-yellow-500 text-xl p-6 rounded-lg min-h-[120px]
+    <div class="bg-blue-900 text-yellow-500 text-xl p-6 rounded-lg min-h-[80px]
                 flex items-center justify-center">
       <%= clue.clue_text %>
     </div>

--- a/app/views/drills/_clue_form.html.erb
+++ b/app/views/drills/_clue_form.html.erb
@@ -1,5 +1,5 @@
 <%# TODO: Partial this up %>
-<div class="bg-white rounded-lg shadow-lg p-8">
+<div class="bg-white rounded-lg shadow-lg p-4 md:p-6">
   <%= render partial: "drills/clue", locals: { clue: clue } %>
   <!-- Response Form -->
   <%= form_with model: drill_clue,
@@ -9,7 +9,7 @@
                   turbo_frame: "drill_clue_frame",
                   action: "turbo:submit-start->response-timer#beforeSubmit"
                 },
-                class: "space-y-4" do |form| %>
+                class: "space-y-3" do |form| %>
     <%= form.hidden_field :clue_id, value: clue.id %>
     <%= form.hidden_field :response_time,
                           value: 0,
@@ -25,7 +25,7 @@
                           autocomplete: "off",
                           data: { response_timer_target: "input" },
                           class:
-                          "w-full px-4 py-3 text-lg border-2 border-gray-300
+                          "w-full px-4 py-2 text-lg border-2 border-gray-300
                           rounded-lg focus:border-indigo-500 focus:ring-2
                           focus:ring-indigo-200" %>
     </div>

--- a/app/views/drills/training.html.erb
+++ b/app/views/drills/training.html.erb
@@ -1,22 +1,29 @@
-<div class="max-w-4xl mx-auto mt-8 p-6">
-  <%= render "active_filters", drill: @drill %>
+<div class="h-[calc(100dvh-4rem)] overflow-hidden flex flex-col">
+  <%# Filters bar (compact, only if present) %>
+  <div class="px-4 pt-2">
+    <%= render "active_filters", drill: @drill %>
+  </div>
 
-  <%= turbo_frame_tag "drill_clue_frame" do %>
-    <% if @clue.present? %>
-      <%= render "clue_form", drill: @drill, clue: @clue, drill_clue: @drill_clue %>
-    <% else %>
-      <%# TODO: This is lame. batch of ~60 and offer reload instead? %>
-      <div class="text-center py-12">
-        <p class="text-xl text-gray-600">No more clues available!</p>
-        <%= link_to "View Results", drill_path(@drill),
-                    class: "mt-4 inline-block px-6 py-3 bg-indigo-600 text-white rounded-lg" %>
-      </div>
+  <%# Main clue area - this is the only scrollable part %>
+  <div class="flex-1 overflow-y-auto px-4 py-2">
+    <%= turbo_frame_tag "drill_clue_frame" do %>
+      <% if @clue.present? %>
+        <%= render "clue_form", drill: @drill, clue: @clue, drill_clue: @drill_clue %>
+      <% else %>
+        <%# TODO: This is lame. batch of ~60 and offer reload instead? %>
+        <div class="text-center py-12">
+          <p class="text-xl text-gray-600">No more clues available!</p>
+          <%= link_to "View Results", drill_path(@drill),
+                      class: "mt-4 inline-block px-6 py-3 bg-indigo-600 text-white rounded-lg" %>
+        </div>
+      <% end %>
     <% end %>
-  <% end %>
-  <div class= "mt-6 flex justify-center items-center">
-    <div class="flex gap-4 items-center">
+  </div>
+
+  <%# Stats bar - pinned to bottom, never scrolls %>
+  <div class="shrink-0 px-4 py-2 bg-gray-100 border-t border-gray-300">
+    <div class="flex justify-center items-center gap-4">
       <%= render "stats", drill: @drill %>
-      <!-- End Drill Button -->
       <%= button_to "End Drill", end_drills_path,
                     method: :post,
                     form: { data: { turbo_confirm: "Are you sure you want to end this drill?" } },

--- a/test/controllers/drills_controller_test.rb
+++ b/test/controllers/drills_controller_test.rb
@@ -111,6 +111,20 @@ class DrillsControllerTest < ActionDispatch::IntegrationTest
     assert_select "div", text: /Invalid drill ID/i
   end
 
+  test "training view uses viewport-height layout without page scroll" do
+    post start_drills_path
+    assert_response :success
+    assert_select "[class*='overflow-hidden']"
+    assert_select "[class*='flex'][class*='flex-col']"
+  end
+
+  test "training view stats bar is outside scroll area" do
+    post start_drills_path
+    assert_response :success
+    # Stats should be in a non-scrolling area (not inside overflow-y-auto)
+    assert_select "#drill_stats"
+  end
+
   test "start action creates drill with filters" do
     # Start a drill with filters
     post start_drills_path, params: { round: 1, clue_values: [ 200, 400 ] }


### PR DESCRIPTION
Refactor training.html.erb to use a viewport-filling flex layout (h-[calc(100dvh-4rem)]) with overflow-hidden on the outer container. The clue area uses flex-1 overflow-y-auto for content that exceeds viewport, while the stats bar is pinned to the bottom. Reduce padding on clue and form partials for a tighter, scroll-free layout.

TDD: added controller tests asserting viewport layout classes.

Closes #66

https://claude.ai/code/session_01AvX9SAYfSEb4rVPiiBf1zT