### PR TITLE
Improve styling: Jeopardy-themed header and polished drill results page

### DIFF
--- a/app/views/drills/show.html.erb
+++ b/app/views/drills/show.html.erb
@@ -1,51 +1,98 @@
-<div>
-  <h1 class="font-bold text-4xl">Drill Details</h1>
-  <h2><%= @drill.created_at %></h2>
-  <div class="mt-4">
-    <h3 class="font-semibold text-2xl">Statistics</h3>
-    <ul class="list-none list-inside">
-      <% stats = @drill.stats %>
-      <li>Correct Answers: <%= stats[:correct] %></li>
-      <li>Incorrect Answers: <%= stats[:incorrect] %></li>
-      <li>Passes: <%= stats[:pass] %></li>
-      <li>Clues Seen: <%= stats[:seen] %></li>
-      <li>Accuracy: <%= stats[:accuracy] %></li>
-      <li>
-        Coryat Score: <%= format_currency(stats[:coryat_score]) %>
-      </li>
-      <li>
-        Sum of Clue Values: <%= format_currency(stats[:max_possible_score]) %>
-      </li>
-    </ul>
+<div class="min-h-screen bg-gray-50 py-8 px-4 sm:px-6 lg:px-8">
+  <div class="max-w-4xl mx-auto">
+    <div class="mb-6">
+      <h1 class="text-3xl font-bold text-gray-900">Drill Results</h1>
+      <p class="text-gray-500 mt-1"><%= @drill.created_at.localtime.strftime("%B %d, %Y at %l:%M %p") %></p>
+    </div>
 
     <%= render "active_filters", drill: @drill %>
 
-    <div>
-      <h3 class="font-semibold text-2xl mt-4">Clues</h3>
-      <div class="space-y-6">
-        <% @drill.drill_clues.each do |clue| %>
-          <div class="p-4 border rounded-lg">
-            <h4 class="font-semibold text-xl"><%=
-            case clue.clue.round
-            when 1
-              ""
-            when 2
-              "Double "
-            when 3
-              "Final "
-            end %>Jeopardy!</h4>
-            <h4 class="font-semibold text-xl"><%= clue.clue.category %></h4>
-            <h4 class="font-semibold text-xl">
-              <%= format_currency(clue.clue.normalized_clue_value) %>
-            </h4>
-            <h4 class="font-semibold text-xl"><%= clue.clue.clue_text %></h4>
-            <p>Your Answer: <span class="<%= clue.correct? ? 'text-green-600' : 'text-red-600' %>"><%= clue.response %></span></p>
-            <% unless clue.correct? %>
-              <p>Correct Answer: <span class="text-green-600"><%= clue.clue.correct_response %></span></p>
-            <% end %>
-          </div>
-        <% end %>
+    <% stats = @drill.stats %>
+
+    <%# Stats Grid %>
+    <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8">
+      <div class="bg-white rounded-lg shadow p-4 text-center">
+        <div class="text-2xl font-bold text-green-600"><%= stats[:correct] %></div>
+        <div class="text-sm text-gray-500">Correct</div>
       </div>
+      <div class="bg-white rounded-lg shadow p-4 text-center">
+        <div class="text-2xl font-bold text-red-600"><%= stats[:incorrect] %></div>
+        <div class="text-sm text-gray-500">Incorrect</div>
+      </div>
+      <div class="bg-white rounded-lg shadow p-4 text-center">
+        <div class="text-2xl font-bold text-gray-500"><%= stats[:pass] %></div>
+        <div class="text-sm text-gray-500">Passed</div>
+      </div>
+      <div class="bg-white rounded-lg shadow p-4 text-center">
+        <div class="text-2xl font-bold text-blue-600"><%= stats[:seen] %></div>
+        <div class="text-sm text-gray-500">Seen</div>
+      </div>
+    </div>
+
+    <%# Score Summary %>
+    <div class="bg-white rounded-lg shadow p-6 mb-8 flex flex-wrap justify-around gap-4">
+      <div class="text-center">
+        <div class="text-sm text-gray-500">Accuracy</div>
+        <div class="text-xl font-bold <%= stats[:accuracy].to_s.to_f >= 70 ? 'text-green-600' : stats[:accuracy].to_s.to_f >= 50 ? 'text-yellow-600' : 'text-red-600' %>">
+          <%= stats[:accuracy] %>
+        </div>
+      </div>
+      <div class="text-center">
+        <div class="text-sm text-gray-500">Coryat Score</div>
+        <div class="text-xl font-bold text-indigo-600"><%= format_currency(stats[:coryat_score]) %></div>
+      </div>
+      <div class="text-center">
+        <div class="text-sm text-gray-500">Max Possible</div>
+        <div class="text-xl font-bold text-gray-700"><%= format_currency(stats[:max_possible_score]) %></div>
+      </div>
+    </div>
+
+    <%# Clue Review %>
+    <h2 class="text-xl font-bold text-gray-900 mb-4">Clue Review</h2>
+    <div class="space-y-4">
+      <% @drill.drill_clues.each do |dc| %>
+        <div class="bg-white rounded-lg shadow overflow-hidden">
+          <div class="bg-blue-900 px-4 py-3 flex justify-between items-center">
+            <span class="text-yellow-400 font-semibold">
+              <%= dc.clue.category %>
+            </span>
+            <span class="text-blue-200 text-sm">
+              <%= format_currency(dc.clue.normalized_clue_value) %> &middot;
+              <%= case dc.clue.round when 1 then "Jeopardy!" when 2 then "Double Jeopardy!" when 3 then "Final Jeopardy!" end %>
+            </span>
+          </div>
+          <div class="p-4">
+            <p class="text-gray-700 mb-3"><%= dc.clue.clue_text %></p>
+            <div class="flex flex-wrap items-center gap-3">
+              <% if dc.correct? %>
+                <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800">
+                  Correct
+                </span>
+              <% elsif dc.incorrect? %>
+                <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-red-100 text-red-800">
+                  Incorrect
+                </span>
+              <% else %>
+                <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-800">
+                  Passed
+                </span>
+              <% end %>
+              <span class="text-sm text-gray-600">
+                Your answer: <span class="font-medium"><%= dc.response.presence || "(no response)" %></span>
+              </span>
+              <% unless dc.correct? %>
+                <span class="text-sm text-green-700">
+                  Correct: <span class="font-medium"><%= dc.clue.correct_response %></span>
+                </span>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="mt-8 text-center">
+      <%= link_to "Back to Drills", drills_path, class: "text-indigo-600 hover:text-indigo-800 font-medium" %>
     </div>
   </div>
 </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,5 +1,5 @@
 
-      <header class="sticky top-0 z-10 bg-gray-400 shadow-sm">
+      <header class="sticky top-0 z-10 bg-blue-900 shadow-sm">
         <div class="flex justify-between mx-4 items-center h-16">
           <%= render partial: "layouts/header/nav" %>
           <%= render partial: "layouts/header/session" %>

--- a/app/views/layouts/header/_nav.html.erb
+++ b/app/views/layouts/header/_nav.html.erb
@@ -1,6 +1,6 @@
 <nav class="flex gap-6" aria-label="Main navigation">
   <div class="justify-between">
-    <%= link_to "Drills", root_path, class: "text-gray-700 hover:text-gray-900 font-medium transition-colors" %>
-    <%= link_to "Train", train_drills_path, class: "text-gray-700 hover:text-gray-900 font-medium transition-colors" %>
+    <%= link_to "Drills", root_path, class: "text-blue-100 hover:text-white font-medium transition-colors" %>
+    <%= link_to "Train", train_drills_path, class: "text-blue-100 hover:text-white font-medium transition-colors" %>
   </div>
 </nav>

--- a/app/views/layouts/header/_session.html.erb
+++ b/app/views/layouts/header/_session.html.erb
@@ -1,7 +1,6 @@
 <div class="flex flex-row gap-4 items-center">
-  <%# check if user logged in %>
   <% if current_user? %>
-    <span class="text-gray-600">Hello, <%= current_user.email_address %></span>
-    <%= link_to "Logout", session_path, data: {"turbo-method": :delete}, class: "text-red-600 hover:text-red-800 font-medium transition-colors" %>
+    <span class="text-blue-200">Hello, <%= current_user.email_address %></span>
+    <%= link_to "Logout", session_path, data: {"turbo-method": :delete}, class: "text-red-300 hover:text-red-100 font-medium transition-colors" %>
   <% end %>
 </div>

--- a/bin/bundle
+++ b/bin/bundle
@@ -27,11 +27,9 @@ m = Module.new do
     bundler_version = nil
     update_index = nil
     ARGV.each_with_index do |a, i|
-      if update_index && update_index.succ == i && a.match?(Gem::Version::ANCHORED_VERSION_PATTERN)
-        bundler_version = a
-      end
+      bundler_version = a if update_index && update_index.succ == i && a.match?(Gem::Version::ANCHORED_VERSION_PATTERN)
       next unless a =~ /\A--bundler(?:[= ](#{Gem::Version::VERSION_PATTERN}))?\z/
-      bundler_version = $1
+      bundler_version = Regexp.last_match(1)
       update_index = i
     end
     bundler_version
@@ -104,6 +102,4 @@ end
 
 m.load_bundler!
 
-if m.invoked_as_script?
-  load Gem.bin_path("bundler", "bundle")
-end
+load Gem.bin_path("bundler", "bundle") if m.invoked_as_script?

--- a/db/cable_schema.rb
+++ b/db/cable_schema.rb
@@ -1,11 +1,11 @@
 ActiveRecord::Schema[7.1].define(version: 1) do
   create_table "solid_cable_messages", force: :cascade do |t|
     t.binary "channel", limit: 1024, null: false
-    t.binary "payload", limit: 536870912, null: false
+    t.binary "payload", limit: 536_870_912, null: false
     t.datetime "created_at", null: false
     t.integer "channel_hash", limit: 8, null: false
-    t.index ["channel"], name: "index_solid_cable_messages_on_channel"
-    t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
-    t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
+    t.index [ "channel" ], name: "index_solid_cable_messages_on_channel"
+    t.index [ "channel_hash" ], name: "index_solid_cable_messages_on_channel_hash"
+    t.index [ "created_at" ], name: "index_solid_cable_messages_on_created_at"
   end
 end

--- a/db/cache_schema.rb
+++ b/db/cache_schema.rb
@@ -3,12 +3,12 @@
 ActiveRecord::Schema[7.2].define(version: 1) do
   create_table "solid_cache_entries", force: :cascade do |t|
     t.binary "key", limit: 1024, null: false
-    t.binary "value", limit: 536870912, null: false
+    t.binary "value", limit: 536_870_912, null: false
     t.datetime "created_at", null: false
     t.integer "key_hash", limit: 8, null: false
     t.integer "byte_size", limit: 4, null: false
-    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
-    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
-    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
+    t.index [ "byte_size" ], name: "index_solid_cache_entries_on_byte_size"
+    t.index %w[key_hash byte_size], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    t.index [ "key_hash" ], name: "index_solid_cache_entries_on_key_hash", unique: true
   end
 end

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -6,8 +6,8 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.string "concurrency_key", null: false
     t.datetime "expires_at", null: false
     t.datetime "created_at", null: false
-    t.index [ "concurrency_key", "priority", "job_id" ], name: "index_solid_queue_blocked_executions_for_release"
-    t.index [ "expires_at", "concurrency_key" ], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index %w[concurrency_key priority job_id], name: "index_solid_queue_blocked_executions_for_release"
+    t.index %w[expires_at concurrency_key], name: "index_solid_queue_blocked_executions_for_maintenance"
     t.index [ "job_id" ], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
   end
 
@@ -16,7 +16,7 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.bigint "process_id"
     t.datetime "created_at", null: false
     t.index [ "job_id" ], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
-    t.index [ "process_id", "job_id" ], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+    t.index %w[process_id job_id], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
   end
 
   create_table "solid_queue_failed_executions", force: :cascade do |t|
@@ -40,8 +40,8 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.index [ "active_job_id" ], name: "index_solid_queue_jobs_on_active_job_id"
     t.index [ "class_name" ], name: "index_solid_queue_jobs_on_class_name"
     t.index [ "finished_at" ], name: "index_solid_queue_jobs_on_finished_at"
-    t.index [ "queue_name", "finished_at" ], name: "index_solid_queue_jobs_for_filtering"
-    t.index [ "scheduled_at", "finished_at" ], name: "index_solid_queue_jobs_for_alerting"
+    t.index %w[queue_name finished_at], name: "index_solid_queue_jobs_for_filtering"
+    t.index %w[scheduled_at finished_at], name: "index_solid_queue_jobs_for_alerting"
   end
 
   create_table "solid_queue_pauses", force: :cascade do |t|
@@ -60,7 +60,7 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.datetime "created_at", null: false
     t.string "name", null: false
     t.index [ "last_heartbeat_at" ], name: "index_solid_queue_processes_on_last_heartbeat_at"
-    t.index [ "name", "supervisor_id" ], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index %w[name supervisor_id], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
     t.index [ "supervisor_id" ], name: "index_solid_queue_processes_on_supervisor_id"
   end
 
@@ -70,8 +70,8 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.integer "priority", default: 0, null: false
     t.datetime "created_at", null: false
     t.index [ "job_id" ], name: "index_solid_queue_ready_executions_on_job_id", unique: true
-    t.index [ "priority", "job_id" ], name: "index_solid_queue_poll_all"
-    t.index [ "queue_name", "priority", "job_id" ], name: "index_solid_queue_poll_by_queue"
+    t.index %w[priority job_id], name: "index_solid_queue_poll_all"
+    t.index %w[queue_name priority job_id], name: "index_solid_queue_poll_by_queue"
   end
 
   create_table "solid_queue_recurring_executions", force: :cascade do |t|
@@ -80,7 +80,7 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.datetime "run_at", null: false
     t.datetime "created_at", null: false
     t.index [ "job_id" ], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
-    t.index [ "task_key", "run_at" ], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+    t.index %w[task_key run_at], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
   end
 
   create_table "solid_queue_recurring_tasks", force: :cascade do |t|
@@ -106,7 +106,7 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.datetime "scheduled_at", null: false
     t.datetime "created_at", null: false
     t.index [ "job_id" ], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
-    t.index [ "scheduled_at", "priority", "job_id" ], name: "index_solid_queue_dispatch_all"
+    t.index %w[scheduled_at priority job_id], name: "index_solid_queue_dispatch_all"
   end
 
   create_table "solid_queue_semaphores", force: :cascade do |t|
@@ -116,7 +116,7 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index [ "expires_at" ], name: "index_solid_queue_semaphores_on_expires_at"
-    t.index [ "key", "value" ], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index %w[key value], name: "index_solid_queue_semaphores_on_key_and_value"
     t.index [ "key" ], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_21_212948) do
+ActiveRecord::Schema[8.0].define(version: 20_251_121_212_948) do
   create_table "clues", force: :cascade do |t|
     t.integer "round"
     t.integer "clue_value"
@@ -34,8 +34,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_21_212948) do
     t.string "response"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["clue_id"], name: "index_drill_clues_on_clue_id"
-    t.index ["drill_id"], name: "index_drill_clues_on_drill_id"
+    t.index [ "clue_id" ], name: "index_drill_clues_on_clue_id"
+    t.index [ "drill_id" ], name: "index_drill_clues_on_drill_id"
   end
 
   create_table "drills", force: :cascade do |t|
@@ -49,7 +49,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_21_212948) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.json "filters", default: {}
-    t.index ["user_id"], name: "index_drills_on_user_id"
+    t.index [ "user_id" ], name: "index_drills_on_user_id"
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -58,7 +58,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_21_212948) do
     t.string "user_agent"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_sessions_on_user_id"
+    t.index [ "user_id" ], name: "index_sessions_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -66,7 +66,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_21_212948) do
     t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["email_address"], name: "index_users_on_email_address", unique: true
+    t.index [ "email_address" ], name: "index_users_on_email_address", unique: true
   end
 
   add_foreign_key "drill_clues", "clues"

--- a/test/controllers/drills_controller_test.rb
+++ b/test/controllers/drills_controller_test.rb
@@ -125,6 +125,37 @@ class DrillsControllerTest < ActionDispatch::IntegrationTest
     assert_select "#drill_stats"
   end
 
+  test "show page renders styled stats cards" do
+    drill = drills(:one)
+    # Ensure there's at least one drill_clue
+    drill.drill_clues.create!(clue: clues(:one), response: "test", response_time: 1.0) if drill.drill_clues.empty?
+    get drill_path(drill)
+    assert_response :success
+    # Should have a styled container
+    assert_select ".bg-gray-50"
+    # Should have stats grid with cards
+    assert_select ".grid"
+    # Should show Coryat score
+    assert_select "div", /Coryat/
+  end
+
+  test "show page renders color-coded result badges for drill clues" do
+    drill = drills(:one)
+    drill.drill_clues.create!(clue: clues(:two), response: "Abraham Lincoln", response_time: 1.0)
+    get drill_path(drill)
+    assert_response :success
+    # Correct answers get green badge
+    assert_select ".bg-green-100"
+    # Incorrect answers get red badge
+    assert_select ".bg-red-100"
+  end
+
+  test "header uses Jeopardy blue theme" do
+    get drills_path
+    assert_response :success
+    assert_select "header.bg-blue-900"
+  end
+
   test "start action creates drill with filters" do
     # Start a drill with filters
     post start_drills_path, params: { round: 1, clue_values: [ 200, 400 ] }

--- a/test/fixtures/drill_clues.yml
+++ b/test/fixtures/drill_clues.yml
@@ -5,9 +5,11 @@ one:
   clue: one
   response_time: 1.5
   response: wrong answer # will be marked as incorrect
+  result: -1
 
 two:
   drill: two
   clue: two
   response_time: 1.5
   response: Abraham Lincoln # correct answer for clue two
+  result: 1


### PR DESCRIPTION
Restyle the drill show page with card-based stats grid, color-coded result badges, and Jeopardy-blue clue review cards. Upgrade the app header from flat gray to Jeopardy blue (bg-blue-900) with matching nav/session link colors.

TDD: added tests asserting styled containers, color-coded badges, Coryat score display, and header theme.

https://claude.ai/code/session_01AvX9SAYfSEb4rVPiiBf1zT