### PR TITLE
feat(judge): per-token spelling ratio for last-name-with-typo matching

### DIFF
--- a/app/services/response_judge.rb
+++ b/app/services/response_judge.rb
@@ -20,6 +20,8 @@ class ResponseJudge
       Result.new(:correct, 1.0, :exact)
     elsif token_subset?
       Result.new(:correct, 1.0, :token_subset)
+    elsif (r = per_token_spelling_ratio) && r >= SPELLING_RATIO_THRESHOLD
+      Result.new(:correct, r, :per_token_spelling)
     elsif (r = spelling_ratio) >= SPELLING_RATIO_THRESHOLD
       Result.new(:correct, r, :spelling)
     else
@@ -46,6 +48,26 @@ class ResponseJudge
 
     min_len = [ 3, c_tokens.map(&:length).min ].min
     u_tokens.all? { |t| t.length >= min_len && c_tokens.include?(t) }
+  end
+
+  def per_token_spelling_ratio
+    u_tokens = user.split
+    c_tokens = correct.split
+    return nil if u_tokens.empty? || c_tokens.empty?
+
+    min_len = [ 3, c_tokens.map(&:length).min ].min
+    return nil unless u_tokens.all? { |t| t.length >= min_len }
+
+    ratios = u_tokens.map do |ut|
+      c_tokens.map { |ct| token_ratio(ut, ct) }.max
+    end
+
+    ratios.min
+  end
+
+  def token_ratio(a, b)
+    distance = Amatch::Levenshtein.new(a).match(b)
+    1.0 - (distance.to_f / [ a.length, b.length ].max)
   end
 
   def spelling_ratio

--- a/test/models/drill_clue_test.rb
+++ b/test/models/drill_clue_test.rb
@@ -175,7 +175,7 @@ class DrillClueTest < ActiveSupport::TestCase
     drill_clue.save
 
     assert drill_clue.correct?, "Minor misspelling should be accepted"
-    assert_equal "spelling", drill_clue.reason
+    assert_includes %w[spelling per_token_spelling], drill_clue.reason
   end
 
   test "short substring does not falsely match" do

--- a/test/services/response_judge_test.rb
+++ b/test/services/response_judge_test.rb
@@ -119,12 +119,38 @@ class ResponseJudgeTest < ActiveSupport::TestCase
     assert_equal :correct, result.verdict
   end
 
+  # --- Per-token spelling tolerance ---
+
+  test "last name with typo matches via per-token spelling" do
+    result = ResponseJudge.call(user_response: "Hemmingway", correct_response: "Who is Ernest Hemingway?")
+    assert_equal :correct, result.verdict
+    assert_equal :per_token_spelling, result.reason
+    assert result.score >= 0.85
+  end
+
+  test "misspelled last name only matches full name" do
+    result = ResponseJudge.call(user_response: "Shakespear", correct_response: "Who is William Shakespeare?")
+    assert_equal :correct, result.verdict
+    assert_equal :per_token_spelling, result.reason
+  end
+
+  test "multiple tokens with typos accepted via per-token spelling" do
+    result = ResponseJudge.call(user_response: "Earnest Hemmingway", correct_response: "Who is Ernest Hemingway?")
+    assert_equal :correct, result.verdict
+    assert_equal :per_token_spelling, result.reason
+  end
+
+  test "per-token spelling rejects short tokens below min length" do
+    result = ResponseJudge.call(user_response: "xx", correct_response: "Who is Abraham Lincoln?")
+    assert_equal :incorrect, result.verdict
+  end
+
   # --- Spelling tolerance (Levenshtein) ---
 
   test "minor misspelling accepted" do
     result = ResponseJudge.call(user_response: "Abrham Lincoln", correct_response: "Who is Abraham Lincoln?")
     assert_equal :correct, result.verdict
-    assert_equal :spelling, result.reason
+    assert_includes %i[spelling per_token_spelling], result.reason
     assert result.score >= 0.85
   end
 


### PR DESCRIPTION
## Summary

- Adds a per-token Levenshtein spelling step between token-subset and whole-string spelling in the `ResponseJudge` match cascade
- For each user token, finds the best-matching correct token by spelling ratio; accepts if all user tokens meet the 0.85 threshold
- Handles the common Jeopardy! case of "last name only, with a typo" — e.g. "Hemmingway" now correctly matches "Ernest Hemingway"

## How it works

The match cascade is now:

1. **Exact** — normalized strings match
2. **Token subset** — all user tokens appear exactly in correct tokens
3. **Per-token spelling** (NEW) — each user token fuzzy-matches its best correct token ≥ 0.85
4. **Whole-string spelling** — full Levenshtein ratio ≥ 0.85

The token length guard (min 3 chars, or shortest correct token length) still applies to prevent short-token false positives.

Closes #110

## Test plan

- [x] "Hemmingway" → "Ernest Hemingway" accepted via per-token spelling
- [x] "Shakespear" → "William Shakespeare" accepted via per-token spelling
- [x] "Earnest Hemmingway" → "Ernest Hemingway" accepted (multi-token typos)
- [x] Short tokens ("xx") still rejected by length guard
- [x] All existing tests pass

https://claude.ai/code/session_01LJcmt24vG4bboHNJU5yEUs

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJcmt24vG4bboHNJU5yEUs)_