### PR TITLE
auth: simplify sign-in/sign-up flow

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -31,7 +31,7 @@ module Authentication
 
     def request_authentication
       session[:return_to_after_authenticating] = request.url
-      redirect_to new_session_path
+      redirect_to sign_in_path
     end
 
     def after_authentication_url

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -7,12 +7,12 @@ class PasswordsController < ApplicationController
       PasswordsMailer.reset(user).deliver_later
     end
 
-    redirect_to new_session_path, notice: "Password reset instructions sent (if user with that email address exists)."
+    redirect_to sign_in_path, notice: "Password reset instructions sent (if user with that email address exists)."
   end
 
   def update
     if @user.update(params.permit(:password, :password_confirmation))
-      redirect_to new_session_path, notice: "Password has been reset."
+      redirect_to sign_in_path, notice: "Password has been reset."
     else
       redirect_to edit_password_path(params[:token]), alert: "Passwords did not match."
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,6 @@
 class SessionsController < ApplicationController
   allow_unauthenticated_access only: %i[ new create ]
-  rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_url, alert: "Try again later." }
+  rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to sign_in_url, alert: "Try again later." }
 
   def new
     @user = User.new
@@ -17,12 +17,12 @@ class SessionsController < ApplicationController
     else
       # TODO: clear flash after unsuccessful login
       # This message persists after fail/pass auth
-      redirect_to new_session_path, alert: "Try another email address or password."
+      redirect_to sign_in_path, alert: "Try another email address or password."
     end
   end
 
   def destroy
     terminate_session
-    redirect_to new_session_path
+    redirect_to sign_in_path
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,16 +7,11 @@ class SessionsController < ApplicationController
   end
 
   def create
-    # FIXME: Strong params
-    # [dev] web.1  | Unpermitted parameters: :authenticity_token, :commit. Context: { controller: SessionsController, action: create, request: #<ActionDispatch::Request:0x00007b21a3ea4c60>, params: {"authenticity_token" => "[FILTERED]", "email_address" => "[FILTERED]", "password" => "[FILTERED]", "commit" => "Sign in", "controller" => "sessions", "action" => "create"} }
-
-    if (@user = User.authenticate_by(params.permit(:email_address, :password)))
+    if (@user = User.authenticate_by(email_address: params[:email_address], password: params[:password]))
+      flash.discard(:alert)
       start_new_session_for @user
       redirect_to after_authentication_url
-      # flash.alert = nil
     else
-      # TODO: clear flash after unsuccessful login
-      # This message persists after fail/pass auth
       redirect_to sign_in_path, alert: "Try another email address or password."
     end
   end

--- a/app/views/layouts/header/_session.html.erb
+++ b/app/views/layouts/header/_session.html.erb
@@ -1,6 +1,6 @@
 <div class="flex flex-row gap-4 items-center">
   <% if current_user? %>
     <span class="text-blue-200">Hello, <%= current_user.email_address %></span>
-    <%= link_to "Logout", session_path, data: {"turbo-method": :delete}, class: "text-red-300 hover:text-red-100 font-medium transition-colors" %>
+    <%= link_to "Sign out", sign_in_path, data: {"turbo-method": :delete}, class: "text-red-300 hover:text-red-100 font-medium transition-colors" %>
   <% end %>
 </div>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -21,4 +21,8 @@
       <%= form.submit "Sign Up", class: "ml-3 inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
     </div>
   <% end %>
+
+  <p class="mt-4 text-center text-sm text-gray-600">
+    Already have an account? <%= link_to "Sign in", sign_in_path, class: "text-indigo-600 hover:text-indigo-500 font-medium" %>
+  </p>
 <% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,5 +1,5 @@
 <%= render 'shared/form_container', title: 'Sign in' do %>
-  <%= form_with url: session_path, class: "space-y-4" do |form| %>
+  <%= form_with url: sign_in_path, class: "space-y-4" do |form| %>
     <%= render 'shared/form_errors' %>
 
     <div>
@@ -21,4 +21,8 @@
       <%= form.submit "Sign in", class: "ml-3 inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
     </div>
   <% end %>
+
+  <p class="mt-4 text-center text-sm text-gray-600">
+    Don't have an account? <%= link_to "Sign up", sign_up_path, class: "text-indigo-600 hover:text-indigo-500 font-medium" %>
+  </p>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,10 @@
 Rails.application.routes.draw do
-  resource :session, only: %i[new create destroy]
-  resolve("Session") { [ :session ] }
-  get "login", to: "sessions#new"
-  post "login", to: "sessions#create"
-  delete "logout", to: "sessions#destroy"
-  get "sign_up", to: "registrations#new"
-  post "sign_up", to: "registrations#create"
-  resources :passwords, param: :token, ony: %i[create update]
+  get    "sign_in", to: "sessions#new",     as: :sign_in
+  post   "sign_in", to: "sessions#create"
+  delete "sign_in", to: "sessions#destroy"
+  get    "sign_up", to: "registrations#new"
+  post   "sign_up", to: "registrations#create"
+  resources :passwords, param: :token, only: %i[new create edit update]
 
   resources :drills, except: %i[edit update destroy] do
     collection do

--- a/test/controllers/drill_clues_controller_test.rb
+++ b/test/controllers/drill_clues_controller_test.rb
@@ -149,6 +149,6 @@ class DrillCluesControllerTest < ActionDispatch::IntegrationTest
   private
 
   def sign_in(user)
-    post session_url, params: { email_address: user.email_address, password: "password" }
+    post sign_in_url, params: { email_address: user.email_address, password: "password" }
   end
 end

--- a/test/controllers/drills_controller_test.rb
+++ b/test/controllers/drills_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class DrillsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:one)
-    post session_path, params: { email_address: @user.email_address, password: "password" }
+    post sign_in_path, params: { email_address: @user.email_address, password: "password" }
   end
   test "gets drill index" do
     get drills_path


### PR DESCRIPTION
## Summary

- Replaces `resource :session` and duplicate `login`/`logout` aliases with explicit `sign_in`/`sign_up` named routes — cleaner and more RESTful
- Adds cross-navigation links between sign-in and sign-up pages (better UX for new users and those who click the wrong page)
- Fixes `ony:` typo in passwords routes and expands to include `new`/`edit` actions
- Renames "Logout" button to "Sign out" for consistency with sign-in/sign-up terminology
- Removes strong-params permit logging noise by passing individual field values to `authenticate_by`
- Discards stale failed-login alerts before successful redirects

## Test plan

- [x] All 84 tests pass
- [x] Sign-in and sign-up pages render with cross-links
- [x] Login flow works end-to-end
- [x] No unpermitted-parameter warnings in logs
- [x] Failed login alerts don't persist after successful login

🤖 Generated with [Claude Code](https://claude.com/claude-code)